### PR TITLE
chore: Another attempt at fixing the stack trace parsing.

### DIFF
--- a/lib/logger.dart
+++ b/lib/logger.dart
@@ -12,11 +12,11 @@ class _StackFrame {
   const _StackFrame(this.file, this.line, this.column);
 
   @override
-  String toString() => 'lib/$file:$line:$column';
+  String toString() => '$file:$line:$column';
 
   static _StackFrame? fromString(String frame) {
-    final match = RegExp(r'package(?:s/|:)tokhub/([^ :]+)[: ](\d+):(\d+)')
-        .firstMatch(frame);
+    final match =
+        RegExp(r'packages?[:/]([^ :]+)[: ](\d+):(\d+)').firstMatch(frame);
     if (match == null) return null;
     return _StackFrame(
       match.group(1)!,


### PR DESCRIPTION
This worked locally but not on the deployed version. Let's see if this works.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/TokTok/tokhub/17)
<!-- Reviewable:end -->
